### PR TITLE
Lower required version to `0.7.0`

### DIFF
--- a/src/module.json
+++ b/src/module.json
@@ -3,13 +3,13 @@
   "title": "Lock & Key",
   "description": "Adding the ability to unlock doors if an actor has a specified item",
   "author": "zstix",
-  "minimumCoreVersion": "1.3.4",
+  "minimumCoreVersion": "0.7.0",
 
-  "version": "0.0.2",
+  "version": "0.0.3",
 
   "scripts": ["scripts/index.js"],
 
   "url": "https://github.com/zstix/fvtt-lock-and-key",
-  "manifest": "https://github.com/zstix/fvtt-lock-and-key/releases/download/0.0.2/module.json",
-  "download": "https://github.com/zstix/fvtt-lock-and-key/releases/download/0.0.2/module.zip"
+  "manifest": "https://github.com/zstix/fvtt-lock-and-key/releases/download/0.0.3/module.json",
+  "download": "https://github.com/zstix/fvtt-lock-and-key/releases/download/0.0.3/module.zip"
 }


### PR DESCRIPTION
I should probably lower this further, depending on what I need from FVTT.